### PR TITLE
Add side-scrolling camera behavior

### DIFF
--- a/GameConfig.swift
+++ b/GameConfig.swift
@@ -8,7 +8,8 @@ enum GameConfig {
     /// Upward impulse applied when jumping.
     /// Higher value gives a more "Mario" style arc.
     static let jumpImpulse            = CGVector(dx: 0, dy: 480)
-    static let cameraLead: CGFloat    = 140        // Camera looks ahead of Sung
+    /// Distance from the screen edge before the camera begins scrolling.
+    static let cameraEdge: CGFloat    = 140
 
     static let enemySpawnGap: CGFloat = 500        // Distance between enemy spawns
     static let envSpawnGap: CGFloat   = 300        // Distance between background buildings

--- a/GameScene.swift
+++ b/GameScene.swift
@@ -100,9 +100,14 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         // Move left/right
         sung.physicsBody?.velocity.dx = CGFloat(moveDir) * GameConfig.runSpeed
 
-        // Camera follow
-        camera?.position = CGPoint(x: sung.position.x + GameConfig.cameraLead,
-                                   y: frame.midY)
+        // Camera follow with a soft edge so Sung can run toward the screen side
+        if let cam = camera {
+            let edge = GameConfig.cameraEdge
+            let dx = sung.position.x - cam.position.x
+            if dx > edge { cam.position.x = sung.position.x - edge }
+            if dx < -edge { cam.position.x = sung.position.x + edge }
+            cam.position.y = frame.midY
+        }
 
         // Spawn scenery & enemies
         spawnEnemiesIfNeeded()


### PR DESCRIPTION
## Summary
- adjust camera behavior so the world scrolls when Sung approaches the screen edge
- rename `cameraLead` to `cameraEdge` in `GameConfig`

## Testing
- `swiftc -o /tmp/app *.swift` *(fails: no such module 'SwiftUI')*