### PR TITLE
Add gavel mechanics and tenant patrol behavior

### DIFF
--- a/GameConfig.swift
+++ b/GameConfig.swift
@@ -13,5 +13,9 @@ enum GameConfig {
     static let enemySpawnGap: CGFloat = 500        // Distance between enemy spawns
     static let envSpawnGap: CGFloat   = 300        // Distance between background buildings
 
+    static let tenantPatrolRange: CGFloat = 80     // How far tenants pace
+    static let gavelUpTime: TimeInterval   = 1.0   // Time gavel stays raised
+    static let gavelDownTime: TimeInterval = 2.0   // Time between raises
+
     static let skyColor               = UIColor.cyan.withAlphaComponent(0.15)
 }

--- a/GameScene.swift
+++ b/GameScene.swift
@@ -7,6 +7,7 @@ struct PhysicsCategory {
     static let ground: UInt32 = 1 << 1
     static let judge:  UInt32 = 1 << 2
     static let tenant: UInt32 = 1 << 3
+    static let gavel:  UInt32 = 1 << 4
 }
 
 // MARK: - Main Scene
@@ -51,7 +52,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         sung.physicsBody = SKPhysicsBody(circleOfRadius: 25)
         sung.physicsBody?.allowsRotation = false
         sung.physicsBody?.categoryBitMask = PhysicsCategory.sung
-        sung.physicsBody?.contactTestBitMask = PhysicsCategory.judge | PhysicsCategory.tenant
+        sung.physicsBody?.contactTestBitMask = PhysicsCategory.judge | PhysicsCategory.tenant | PhysicsCategory.gavel
         sung.physicsBody?.collisionBitMask = PhysicsCategory.ground | PhysicsCategory.judge | PhysicsCategory.tenant
         addChild(sung)
     }
@@ -125,12 +126,50 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             enemy.physicsBody?.collisionBitMask = PhysicsCategory.none
             addChild(enemy)
 
-            let speed: CGFloat = 100
-            let distance       = enemy.position.x + 1000
-            enemy.run(.sequence([.moveBy(x: -distance, y: 0,
-                                         duration: TimeInterval(distance / speed)),
-                                 .removeFromParent()]))
+            enemy.run(.sequence([.wait(forDuration: 30), .removeFromParent()]))
+
+            if isJudge {
+                addGavel(to: enemy)
+            } else {
+                addTenantMovement(to: enemy)
+            }
         }
+    }
+
+    private func addTenantMovement(to enemy: SKNode) {
+        let range = GameConfig.tenantPatrolRange
+        let duration = TimeInterval(range / 40)
+        let moveLeft = SKAction.moveBy(x: -range, y: 0, duration: duration)
+        let moveRight = SKAction.moveBy(x: range, y: 0, duration: duration)
+        enemy.run(.repeatForever(.sequence([moveLeft, moveRight])))
+    }
+
+    private func addGavel(to enemy: SKNode) {
+        let gavel = Sprites.make(.gavel, size: CGSize(width: 20, height: 20))
+        gavel.position = CGPoint(x: 0, y: 40)
+        gavel.isHidden = true
+        gavel.physicsBody = SKPhysicsBody(rectangleOf: gavel.size)
+        gavel.physicsBody?.isDynamic = false
+        gavel.physicsBody?.categoryBitMask = PhysicsCategory.none
+        gavel.physicsBody?.contactTestBitMask = PhysicsCategory.sung
+        gavel.physicsBody?.collisionBitMask = PhysicsCategory.none
+        enemy.addChild(gavel)
+
+        let raise = SKAction.run {
+            gavel.isHidden = false
+            gavel.physicsBody?.categoryBitMask = PhysicsCategory.gavel
+        }
+        let lower = SKAction.run {
+            gavel.isHidden = true
+            gavel.physicsBody?.categoryBitMask = PhysicsCategory.none
+        }
+        let cycle = SKAction.sequence([
+            .wait(forDuration: GameConfig.gavelDownTime),
+            raise,
+            .wait(forDuration: GameConfig.gavelUpTime),
+            lower
+        ])
+        gavel.run(.repeatForever(cycle))
     }
 
     private func spawnEnvironmentIfNeeded() {
@@ -155,6 +194,12 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         let other = contact.bodyA.categoryBitMask == PhysicsCategory.sung
                     ? contact.bodyB : contact.bodyA
         guard let node = other.node else { return }
+
+        if other.categoryBitMask == PhysicsCategory.gavel {
+            showMessage("OTSC GRANTED")
+            endGame()
+            return
+        }
 
         let stomp = sung.position.y > node.position.y + 20 &&
                    (sung.physicsBody?.velocity.dy ?? 0) < 0

--- a/Sprites.swift
+++ b/Sprites.swift
@@ -5,7 +5,7 @@ import UIKit
 /// if none, falls back to an SF-Symbol icon; if that fails, a solid color box.
 enum Sprites {
 
-    enum Kind { case sung, judge, tenant, house, building }
+    enum Kind { case sung, judge, tenant, gavel, house, building }
 
     static func make(_ kind: Kind, size: CGSize) -> SKSpriteNode {
         let (png, symbol, tint): (String, String, UIColor) = {
@@ -13,6 +13,7 @@ enum Sprites {
             case .sung:      return ("sung",      "person.circle.fill",        .systemBlue)
             case .judge:     return ("judge",     "theatermasks.circle.fill",  .systemPurple)
             case .tenant:    return ("tenant",    "person.circle",             .systemRed)
+            case .gavel:     return ("gavel",     "hammer.circle.fill",        .brown)
             case .house:     return ("house",     "house.fill",                .systemGreen)
             case .building:  return ("building",  "building.2.fill",           .systemTeal)
             }


### PR DESCRIPTION
## Summary
- give tenants a back-and-forth patrol
- create a gavel sprite and attach it to judges
- animate gavels raising and lowering; hitting a raised gavel ends the game
- expose new constants for tenant patrol range and gavel timings

## Testing
- `swiftc -frontend -parse GameScene.swift ContentView.swift TouchControls.swift Sprites.swift GameConfig.swift MyApp.swift`